### PR TITLE
Modified some bugs in main.cpp and main_seq.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -184,9 +184,11 @@ void average_weights(double *weights, int weight_size, int rank){
     // int weight_size = CONV_MAT_SIZE*NUM_FILTERS*NUM_CLASSES;
     double *all_weights;
     double *weight_avg;
+    double* dis_weight_avg;
 
     all_weights = (double *) malloc(NUM_PROCESSORS*weight_size*sizeof(double));
     weight_avg = (double *) malloc(weight_size*sizeof(double));
+    dis_weight_avg = (double*)malloc(NUM_PROCESSORS * weight_size * sizeof(double));
 
     MPI_Gather(weights, weight_size, MPI_DOUBLE, 
                all_weights, weight_size, MPI_DOUBLE, 
@@ -205,12 +207,17 @@ void average_weights(double *weights, int weight_size, int rank){
         }
         for (auto i = 0; i < weight_size; i++)
             weight_avg[i] /= NUM_PROCESSORS;
+
+        for (int i = 0; i < NUM_PROCESSORS; i++) {
+            memcpy(&dis_weight_avg[i * weight_size], weight_avg, weight_size * sizeof(double));
+        }
     }
 
-    MPI_Scatter(weight_avg, weight_size, MPI_DOUBLE,
+    MPI_Scatter(dis_weight_avg, weight_size, MPI_DOUBLE,
                 weights, weight_size, MPI_DOUBLE, 
                 0, MPI_COMM_WORLD);
 
+    free(dis_weight_avg);
     free(all_weights);
     free(weight_avg);
 }

--- a/main_seq.cpp
+++ b/main_seq.cpp
@@ -34,7 +34,7 @@ int main(){
         double loss = 0;
         double acc = 0;
         cout<<"running epoch "<<epoch+1<<endl;
-        for (auto i = 0; i < images.size(); i++){
+        for (auto i = 0; i < images.size() -1; i++){
             image = images[i];
             label = labels[i];
             // print_matrix(subtract_matrices(images[i], images[i+1]));


### PR DESCRIPTION
1.Modified the upper limit of the loop in main_seq.cpp to prevent overflow,Avoid the overflow problem caused by accessing images[i+1] when i=images.size()

2.Modified the parameters of MPI_Scatter in main.cpp and added a new array to fix the problem that the original weight_avg capacity is not large enough.  
For the first parameter of MPI_Scatter, we expect its size to be NUM_PROCESSORS*weight_size. In this way we can redistribute them among NUM_PROCESSORS processes. In the source code, the first parameter of MPI_Scatter is weight_avg, which has the same size as weights (i.e. recvbuf). When we try to distribute it to NUM_PROCESSORS processes, an error will occur and subsequent parameters will go out of bounds.
So we add a new dis_weight_avg variable to the average_weights function to store four identical weight_avg arrays and use it as the first parameter of MPI_Scatter. After my experiments, this can solve the problem of loss becoming -inf after multiple opoch training.

Hope my suggestions will work.
